### PR TITLE
Adding archive notice to top of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!WARNING]
+> **This repository has been archived as of 2026-01-12.** The functionality has been migrated and expanded upon in the [WILDS WDL Library](https://github.com/getwilds/wilds-wdl-library) as the [`ww-leukemia` pipeline](https://github.com/getwilds/wilds-wdl-library/tree/main/pipelines/ww-leukemia). Please refer to that instance for the latest versions, documentation, and updates.
+
 # ww-vc-trio
 [![Project Status: Experimental – Useable, some support, not open to feedback, unstable API.](https://getwilds.org/badges/badges/experimental.svg)](https://getwilds.org/badges/#experimental)
 


### PR DESCRIPTION
## Description
- With the expansion of the WILDS WDL Library, this pipeline has been migrated (and expanded upon) in the library accordingly and this standalone repo is no longer needed. To preserve contributions, we will archive the repo rather than delete it, but redirect folks to the WILDS WDL Library via a blurb at the top of the README.
- Tagging @sminot for visibility. Thank you for your efforts on this!